### PR TITLE
Remove keep alive step to prevent blocking/failing cron

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -67,9 +67,3 @@ jobs:
         run: |
           export PYTHONPATH=$(pwd):$PYTHONPATH
           pipenv run scrapy combinefeeds -s LOG_ENABLED=False
-
-      - name: Prevent workflow deactivation
-        uses: gautamkrishnar/keepalive-workflow@v1
-        with:
-          committer_username: "citybureau-bot"
-          committer_email: "documenters@citybureau.org"


### PR DESCRIPTION
This PR removes the keepalive-workflow step from the cron workflow.